### PR TITLE
B/customer vault order data

### DIFF
--- a/src/Message/DirectPostAuthRequest.php
+++ b/src/Message/DirectPostAuthRequest.php
@@ -18,7 +18,7 @@ class DirectPostAuthRequest extends AbstractRequest
         if ($this->getCardReference()) {
             $data['customer_vault_id'] = $this->getCardReference();
 
-            return $data;
+           return array_merge($data, $this->getOrderData());
         } else {
             $this->getCard()->validate();
 


### PR DESCRIPTION
When a sale is attempted using the customer vault, order data such as `orderdescription` and `orderid` are not included in the request. This change merges the order data so it's included.